### PR TITLE
refactor: include available room count and hotel capacity

### DIFF
--- a/src/repositories/hotel-repository/index.ts
+++ b/src/repositories/hotel-repository/index.ts
@@ -1,7 +1,31 @@
 import { prisma } from "@/config";
 
 async function findHotels() {
-  return prisma.hotel.findMany();
+  return prisma.$queryRaw`
+    WITH rooms_hotels AS (
+      SELECT
+        hotels.id,
+        COUNT(boo."userId") as users
+      FROM
+        "Hotel" hotels
+      INNER JOIN "Room" rooms ON rooms."hotelId" = hotels.id
+      INNER JOIN "Booking" boo ON boo."roomId" = rooms.id
+      GROUP BY hotels.id
+    )
+    SELECT
+      hotels.id,
+      hotels.name,
+      hotels.image,
+      MAX(rooms.capacity) AS capacity,
+      SUM(rooms.capacity) - rooms_hotels.users AS "availableRooms"
+    FROM 
+      "Room" rooms 
+    INNER JOIN "Hotel" hotels ON rooms."hotelId" = hotels.id
+    INNER JOIN rooms_hotels ON rooms_hotels.id = hotels.id
+    GROUP BY 
+      hotels.id,
+      rooms_hotels.users
+  `;
 }
 
 async function findRoomsByHotelId(hotelId: number) {
@@ -11,7 +35,7 @@ async function findRoomsByHotelId(hotelId: number) {
     },
     include: {
       Rooms: true,
-    }
+    },
   });
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
- [ ] Release (new version of the application - only for production)

## Description

- I changed the search done by the Prisma with `findMany` to `$queryRaw`, making it possible to do a more complex search.
- I adapted the query to send the maximum capacity of the rooms in the respective hotels.
- I added the available count of rooms in the hotel to the query.

## Screenshots

![image](https://user-images.githubusercontent.com/106272711/222599997-c2577e10-e554-40cf-b498-45673e6ea166.png)


## Tasks

- Eu como usuário com ingresso pago que inclui hotel, quero ver os hotéis disponíveis e suas informações

## Checklist

- [x] My changes have less than or equal 400 lines
- [ ] I have performed a self-review of my own code
- [ ] The existing tests and linter pass locally with my changes
- [ ] I have commented my code in hard-to-understand areas (if applicable)
- [ ] I have created tests for my fix or feature (if applicable)

## Dependencies

This pull request has a dependency on the following others:

- N/A
